### PR TITLE
Call SmartDeleteFile when deleting files inside a Directory

### DIFF
--- a/KuduSync.NET/KuduSync.cs
+++ b/KuduSync.NET/KuduSync.cs
@@ -250,7 +250,7 @@ namespace KuduSync.NET
                 {
                     _logger.Log("Deleting file: '{0}'", previousFilePath);
                     var inclosuresafe = file;
-                    OperationManager.Attempt(() => inclosuresafe.Delete());
+                    OperationManager.Attempt(() => SmartDeleteFile(inclosuresafe));
                 }
             }
 


### PR DESCRIPTION
This is why @DamianEdwards was seeing random access denied when publishing some aspnet 5.

The reason this isn't common is because it's a corner case that I don't think any other framework uses except for AspNet 5.
Basically this code path is only called if there is a folder in the site that's no longer in the repo, and we need to call delete on all the files in that folder. usually we only have dlls in the bin folder, and I guess the case of deleting the whole bin folder isn't common. But with AspNet 5 each dll lives in its own folder, so if you remove a package between deployments, we try to delete the whole folder and we weren't trying the 'rename on lock' trick and hence the failure. 