### PR TITLE
Fix - avoid false positives in IsSubDirectory

### DIFF
--- a/KuduSync.NET/FileSystemHelpers.cs
+++ b/KuduSync.NET/FileSystemHelpers.cs
@@ -73,10 +73,14 @@ namespace KuduSync.NET
 
         public static bool IsSubDirectory(string path1, string path2)
         {
+            // Avoid false positives when comparing source and destination names.
+            // i.e. Compare 'directory\' to 'directory23\'
+            // rather than 'directory' to 'directory23'
+            char separator = Path.DirectorySeparatorChar;
             if (path1 != null && path2 != null)
             {
-                path1 = Path.GetFullPath(path1);
-                path2 = Path.GetFullPath(path2);
+                path1 = Path.GetFullPath(path1) + separator;
+                path2 = Path.GetFullPath(path2) + separator;
                 return path2.StartsWith(path1, StringComparison.OrdinalIgnoreCase);
             }
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ This is the .NET version of [KuduSync](https://github.com/projectkudu/KuduSync).
 
 ### Usage
 
-KuduSync.NET.exe `-f [source path] -t [destination path] -n [path to next manifest path] -p [path to current manifest path] -i <paths to ignore delimited by ;>`
+```
+KuduSync.NET.exe -f [source path] -t [destination path] -n [path to next manifest path]
+                 -p [path to current manifest path] -i <paths to ignore delimited by ;>
+```
 
 The tool will sync files from the `[source path]` path to the `[destination path]` path using the manifest file in `[path to current manifest path]` to help determine what was added/removed and will write the new manifest file at path `[path to current manifest path]`.
 Paths in `<paths to ignore>` will be ignored in the process


### PR DESCRIPTION
Fixes https://github.com/projectkudu/KuduSync.NET/issues/15

BEFORE
```cmd
C:\>KuduSync.NET.exe -x -f c:\tmp\folder -t c:\tmp\folder2
Error: Source and destination directories cannot be sub-directories of each other
```

AFTER
```cmd
C:\>KuduSync.NET.exe -x -f c:\tmp\folder -t c:\tmp\folder2
KuduSync.NET from: 'c:\tmp\folder' to: 'c:\tmp\folder2'
Copying file: 'hello.txt'
```

All tests pass:
```
  ✔ 26 tests complete (9.779 seconds)

============
Tests passed
============
```