### PR TITLE
Adds new option for full text comparison just like the web.config does (issue #17)

### DIFF
--- a/KuduSync.NET/FileInfoBaseExtensions.cs
+++ b/KuduSync.NET/FileInfoBaseExtensions.cs
@@ -1,15 +1,25 @@
 ﻿using System;
 using System.IO.Abstractions;
+using System.Linq;
 using System.Security.Cryptography;
+using System.Text.RegularExpressions;
 
 namespace KuduSync.NET
 {
     static class FileInfoBaseExtensions
     {
-        public static bool IsWebConfig(this FileInfoBase file)
+        public static bool IsFullTextCompareFile(this FileInfoBase file, KuduSyncOptions kuduSyncOptions)
         {
-            return file.Name.Equals("web.config", StringComparison.OrdinalIgnoreCase);
+            var matched = kuduSyncOptions.GetFullTextCompareFilePatterns()
+                .Any(fileMatchPattern => Regex.IsMatch(file.Name, WildCardToRegular(fileMatchPattern), RegexOptions.IgnoreCase));
+
+            return matched;
         }
+
+        private static string WildCardToRegular(string value)
+        {
+            return "^" + Regex.Escape(value).Replace("\\?", ".").Replace("\\*", ".*") + "$";
+        }        
 
         public static string ComputeSha1(this FileInfoBase file)
         {

--- a/KuduSync.NET/KuduSync.cs
+++ b/KuduSync.NET/KuduSync.cs
@@ -194,9 +194,9 @@ namespace KuduSync.NET
 
                 var details = FileSystemHelpers.GetRelativePath(sourcePath, sourceFile.FullName) + (_options.CopyMetaData ? " " + ShorthandAttributes(sourceFile) : String.Empty);
 
-                if (sourceFile.IsWebConfig())
+                if (sourceFile.IsFullTextCompareFile(_options))
                 {
-                    // If current file is web.config check the content sha1.
+                    // If current file matches the passed in file match patterns check the content sha1.
                     if (!destFilesLookup.TryGetValue(sourceFile.Name, out targetFile) ||
                         !sourceFile.ComputeSha1().Equals(targetFile.ComputeSha1()))
                     {

--- a/KuduSync.NET/KuduSyncOptions.cs
+++ b/KuduSync.NET/KuduSyncOptions.cs
@@ -80,6 +80,8 @@ namespace KuduSync.NET
                     .Where(fileMatch => !string.IsNullOrWhiteSpace(fileMatch))
                     //cannot contain illegal file chars apart from the wildcard chars (* or ?)
                     .Where(fileMatch => !fileMatch.Any(ch => invalid.Contains(ch)))
+                    //Ensure web.config is always in the list
+                    .Union(new [] { "web.config" })
                     .ToArray();
             }
             return _fullTextCompareFilePatterns;


### PR DESCRIPTION
This addresses the details listed in issue #17 

I've added a new optional argument called `fullCompareFiles`. By default this optional argument returns "web.config". I've replaced the `IsWebConfig` method with `IsFullTextCompareFile` and since by default the option value is "web.config" this will perform the same check.

If fullCompareFiles is specified, it supports 2 types of wildcard chars: 

```
  ? - any character  (one and only one)
  * - any characters (zero or more)
```

The value for fullCompareFile is semicolon delimited and there is logic built in to always ensure that `web.config` is in this list. This logic also ensures that the values entered are valid values, it will remove any pattern that is invalid.