### PR TITLE
Ensure that app_offline.htm is not deleted when overwritten

### DIFF
--- a/KuduSync.NET/Program.cs
+++ b/KuduSync.NET/Program.cs
@@ -107,7 +107,8 @@ namespace KuduSync.NET
         private static bool RemoveAppOffline(string toDirectory, Logger logger)
         {
             var appOffline = Path.Combine(toDirectory, AppOfflineFileName);
-            if (!File.Exists(appOffline))
+            // If app_offline.htm does not exist or if it's overwritten, we don't have to delete it
+            if (!File.Exists(appOffline) || !File.ReadAllText(appOffline).Equals(AppOfflineFileContent))
             {
                 return true;
             }


### PR DESCRIPTION
If the user is trying to deploy `app_offline.htm` from from their source, we may hit a weird behavior- 
-- we create our `app_offline.htm` 
-- our `app_offline.htm` is overwritten by the user's `app_offline.htm`
-- we delete our `app_offline.htm` that was overwritten by the user's

In this scenario, user will not be able to deploy their `app_offline.htm`

I added a small fix to only delete the `app_offline.htm`, if it has the exact same content as what we wrote. I don't think we have to worry about the rarest scenario when the user is trying to deploy `app_offline.htm` with the exact same content as ours and hasn't turned off the app setting.