### PR TITLE
Increase the default retries to 10

### DIFF
--- a/KuduSync.NET/OperationManager.cs
+++ b/KuduSync.NET/OperationManager.cs
@@ -5,7 +5,7 @@ namespace KuduSync.NET
 {
     internal static class OperationManager
     {
-        private const int DefaultRetries = 3;
+        private const int DefaultRetries = 10;
         private const int DefaultDelayBeforeRetry = 250; // 250 ms
 
         public static void Attempt(Action action, int retries = DefaultRetries, int delayBeforeRetry = DefaultDelayBeforeRetry)


### PR DESCRIPTION
I increased the default retries instead of just increasing the number for copying. Just so, we could face similar problems with deleting or really any other operation.