### PR TITLE
Updating net4.5 to 4.8 and nuget version to 1.5.4

### DIFF
--- a/KuduSync.NET.nuspec
+++ b/KuduSync.NET.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>KuduSync.NET</id>
-    <version>1.5.3</version>
+    <version>1.5.4</version>
     <authors>amitap</authors>
     <owners>amitap</owners>
     <licenseUrl>https://github.com/projectkudu/KuduSync.NET/blob/master/LICENSE.txt</licenseUrl>

--- a/KuduSync.NET/App.config
+++ b/KuduSync.NET/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
   </startup>
   <appSettings>
     <add key="KuduSyncDataDirectory" value="%home%\data\kudusync" />

--- a/KuduSync.NET/KuduSync.NET.csproj
+++ b/KuduSync.NET/KuduSync.NET.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>KuduSync.NET</RootNamespace>
     <AssemblyName>KuduSync.NET</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/KuduSync.NET/packages.config
+++ b/KuduSync.NET/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommandLineParser" version="1.9.3.34" targetFramework="net45" />
-  <package id="System.IO.Abstractions" version="1.4.0.66" targetFramework="net45" />
+  <package id="CommandLineParser" version="1.9.3.34" targetFramework="net48" />
+  <package id="System.IO.Abstractions" version="1.4.0.66" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
This is to pick the changes made by previous https://github.com/projectkudu/KuduSync.NET/pull/30 which is associated with the github issue: https://github.com/Azure/webapps-deploy/issues/201


4.5 -> 4.8 because 4.5 is EOL. 